### PR TITLE
Fix #45 & #46 - Paste text enhancement

### DIFF
--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -24,7 +24,9 @@ class MyApp extends StatelessWidget {
 
 class PinCodeVerificationScreen extends StatefulWidget {
   final String phoneNumber;
+
   PinCodeVerificationScreen(this.phoneNumber);
+
   @override
   _PinCodeVerificationScreenState createState() =>
       _PinCodeVerificationScreenState();
@@ -35,12 +37,13 @@ class _PinCodeVerificationScreenState extends State<PinCodeVerificationScreen> {
 
   TextEditingController textEditingController = TextEditingController()
     ..text = "123456";
-  
+
   StreamController<ErrorAnimationType> errorController;
 
   bool hasError = false;
   String currentText = "";
   final GlobalKey<ScaffoldState> scaffoldKey = GlobalKey<ScaffoldState>();
+
   @override
   void initState() {
     onTapRecognizer = TapGestureRecognizer()
@@ -134,7 +137,6 @@ class _PinCodeVerificationScreenState extends State<PinCodeVerificationScreen> {
                     errorAnimationController: errorController,
                     controller: textEditingController,
                     onCompleted: (v) {
-                      
                       print("Completed");
                     },
                     onChanged: (value) {
@@ -142,6 +144,10 @@ class _PinCodeVerificationScreenState extends State<PinCodeVerificationScreen> {
                       setState(() {
                         currentText = value;
                       });
+                    },
+                    beforeTextPaste: (text) {
+                      print("Allowing to paste $text");
+                      return true;
                     },
                   )),
               Padding(
@@ -181,7 +187,8 @@ class _PinCodeVerificationScreenState extends State<PinCodeVerificationScreen> {
                     onPressed: () {
                       // conditions for validating
                       if (currentText.length != 6 || currentText != "towtow") {
-                        errorController.add(ErrorAnimationType.shake); // Triggering error shake animation
+                        errorController.add(ErrorAnimationType
+                            .shake); // Triggering error shake animation
                         setState(() {
                           hasError = true;
                         });

--- a/lib/pin_code_fields.dart
+++ b/lib/pin_code_fields.dart
@@ -129,6 +129,10 @@ class PinCodeTextField extends StatefulWidget {
   /// Triggers the error animation
   final StreamController<ErrorAnimationType> errorAnimationController;
 
+  /// Callback method to validate if text can be pasted. This is helpful when we need to validate text before pasting.
+  /// e.g. validate if text is number. Default will be pasted as received.
+  final bool Function(String text) beforeTextPaste;
+
   PinCodeTextField({
     Key key,
     @required this.length,
@@ -174,6 +178,7 @@ class PinCodeTextField extends StatefulWidget {
     this.autoDisposeControllers = true,
     this.onSubmitted,
     this.errorAnimationController,
+    this.beforeTextPaste,
   }) : super(key: key);
 
   @override
@@ -474,7 +479,13 @@ class _PinCodeTextFieldState extends State<PinCodeTextField>
                 ? () async {
                     var data = await Clipboard.getData("text/plain");
                     if (data?.text?.isNotEmpty ?? false) {
-                      _showPasteDialog(data.text);
+                      if (widget.beforeTextPaste != null) {
+                        if (widget.beforeTextPaste(data.text)) {
+                          _showPasteDialog(data.text);
+                        }
+                      } else {
+                        _showPasteDialog(data.text);
+                      }
                     }
                   }
                 : null,

--- a/lib/pin_code_fields.dart
+++ b/lib/pin_code_fields.dart
@@ -187,8 +187,10 @@ class _PinCodeTextFieldState extends State<PinCodeTextField>
   List<String> _inputList;
   int _selectedIndex = 0;
   BorderRadius borderRadius;
+
   // AnimationController for the error animation
   AnimationController _controller;
+
   // Animation for the error animation
   Animation<Offset> _offsetAnimation;
 
@@ -471,7 +473,7 @@ class _PinCodeTextFieldState extends State<PinCodeTextField>
             onLongPress: widget.enabled
                 ? () async {
                     var data = await Clipboard.getData("text/plain");
-                    if (data.text.isNotEmpty) {
+                    if (data?.text?.isNotEmpty ?? false) {
                       _showPasteDialog(data.text);
                     }
                   }


### PR DESCRIPTION
- [FIX] App crashes when clipboard is NULL. Ref issue #45 
- Added beforeTextPaste callback. That can validate text before pasting it. Ref #46.