### PR TITLE
added short delay when refocusing

### DIFF
--- a/lib/pin_code_fields.dart
+++ b/lib/pin_code_fields.dart
@@ -566,9 +566,11 @@ class _PinCodeTextFieldState extends State<PinCodeTextField>
   void _onFocus() {
     if (_focusNode.hasFocus) {
       _focusNode.unfocus();
+      Future.delayed(const Duration(microseconds: 1), () => FocusScope.of(context).requestFocus(_focusNode));
     }
-
-    FocusScope.of(context).requestFocus(_focusNode);
+    else {
+      FocusScope.of(context).requestFocus(_focusNode);
+    }
   }
 
   void _setTextToInput(String data) async {


### PR DESCRIPTION
This fixes the following bug:
after tapping the PinCodeTextField, the keyboard opens, and then if the user presses the 'back' button, the keyboard closes but PinCodeTextField cannot be pressed again.