### PR TITLE
fix: pop dialog from the rootNavigator

### DIFF
--- a/lib/pin_code_fields.dart
+++ b/lib/pin_code_fields.dart
@@ -595,14 +595,14 @@ class _PinCodeTextFieldState extends State<PinCodeTextField>
         FlatButton(
           child: Text(_dialogConfig.negativeText),
           onPressed: () {
-            Navigator.pop(context);
+            Navigator.of(context, rootNavigator: true).pop();
           },
         ),
         FlatButton(
           child: Text(_dialogConfig.affirmativeText),
           onPressed: () {
             _textEditingController.text = pastedText;
-            Navigator.pop(context);
+            Navigator.of(context, rootNavigator: true).pop();
           },
         ),
       ]);
@@ -611,14 +611,14 @@ class _PinCodeTextFieldState extends State<PinCodeTextField>
         CupertinoDialogAction(
           child: Text(_dialogConfig.negativeText),
           onPressed: () {
-            Navigator.pop(context);
+            Navigator.of(context, rootNavigator: true).pop();
           },
         ),
         CupertinoDialogAction(
           child: Text(_dialogConfig.affirmativeText),
           onPressed: () {
             _textEditingController.text = pastedText;
-            Navigator.pop(context);
+            Navigator.of(context, rootNavigator: true).pop();
           },
         ),
       ]);


### PR DESCRIPTION
Hi there. I'm new to Flutter, so please correct me if I'm misunderstanding something here.

I was having trouble closing the paste confirmation dialog when two navigators deep. Clicking either button would not close the dialog, and instead send my rootNavigator back one route.

As of 18 June 2020, the docs below state:

> https://api.flutter.dev/flutter/material/showDialog.html
> By default, useRootNavigator is true and the dialog route created by this method is pushed to the root navigator.

In my case, adding `rootNavigator: true` to `Navigator.pop()` fixed my problem. I would say this should fix problems for others in the same boat as me, without introducing any breaking changes for others.