### PR TITLE
Dispose error animation stream when widget is disposed

### DIFF
--- a/lib/src/pin_code_fields.dart
+++ b/lib/src/pin_code_fields.dart
@@ -178,6 +178,8 @@ class _PinCodeTextFieldState extends State<PinCodeTextField>
   // AnimationController for the error animation
   AnimationController _controller;
 
+  StreamSubscription<ErrorAnimationType> _errorAnimationSubscription;
+
   // Animation for the error animation
   Animation<Offset> _offsetAnimation;
   DialogConfig get _dialogConfig => widget.dialogConfig == null
@@ -225,8 +227,10 @@ class _PinCodeTextFieldState extends State<PinCodeTextField>
         _controller.reverse();
       }
     });
+
     if (widget.errorAnimationController != null) {
-      widget.errorAnimationController.stream.listen((errorAnimation) {
+      _errorAnimationSubscription =
+          widget.errorAnimationController.stream.listen((errorAnimation) {
         if (errorAnimation == ErrorAnimationType.shake) {
           _controller.forward();
         }
@@ -314,6 +318,9 @@ class _PinCodeTextFieldState extends State<PinCodeTextField>
       //       "*** Disposing _textEditingController and _focusNode, To disable this feature please set autoDisposeControllers = false***");
       // }
     }
+
+    _errorAnimationSubscription?.cancel();
+
     _controller.dispose();
     super.dispose();
   }

--- a/test/pin_code_fields_test.dart
+++ b/test/pin_code_fields_test.dart
@@ -1,13 +1,37 @@
+import 'dart:async';
 import 'dart:ui';
 
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
-
-import '../lib/pin_code_fields.dart';
+import 'package:pin_code_fields/pin_code_fields.dart';
 
 void main() {
   final TestWidgetsFlutterBinding binding =
       TestWidgetsFlutterBinding.ensureInitialized();
+
+  testWidgets('disposes error stream', (WidgetTester tester) async {
+    final StreamController<ErrorAnimationType> controller =
+        StreamController<ErrorAnimationType>();
+
+    final Widget app = Builder(
+      builder: (context) => MaterialApp(
+        home: Scaffold(
+          body: PinCodeTextField(
+            appContext: context,
+            length: 6,
+            onChanged: (input) {},
+            errorAnimationController: controller,
+          ),
+        ),
+      ),
+    );
+
+    await tester.pumpWidget(app);
+    expect(controller.hasListener, isTrue);
+
+    await tester.pumpWidget(SizedBox());
+    expect(controller.hasListener, isFalse);
+  });
 
   /// This test demonstrates that a application can set a InputDecorationTheme
   /// which specifies a background color for input fields. When this happens,


### PR DESCRIPTION
Ensures the error animation stream subscription is cancelled when the widget is disposed.