### PR TITLE
Fixed disabled border of invisible slide transition text form field visible when pins are disabled

### DIFF
--- a/lib/src/pin_code_fields.dart
+++ b/lib/src/pin_code_fields.dart
@@ -591,6 +591,7 @@ class _PinCodeTextFieldState extends State<PinCodeTextField>
                     fillColor: widget.backgroundColor,
                     enabledBorder: InputBorder.none,
                     focusedBorder: InputBorder.none,
+                    disabledBorder: InputBorder.none,
                   ),
                   style: TextStyle(
                     color: Colors.transparent,


### PR DESCRIPTION
[
<img width="375" alt="Screenshot 2020-11-25 at 19 23 36" src="https://user-images.githubusercontent.com/33990152/100337070-3a72ac80-2fd7-11eb-9127-9dac4378d812.png">
](url)