### PR TITLE
Implementation of errorBorderColor

### DIFF
--- a/README.md
+++ b/README.md
@@ -242,6 +242,9 @@ A flutter package which will help you to generate pin code fields with beautiful
   /// Colors of the input fields which don't have inputs. Default is [Colors.red]
   final Color inactiveFillColor;
 
+  /// Color of the input field when in error mode. Default is [Colors.redAccent]
+  final Color errorBorderColor;
+
   /// Border radius of each pin code field
   final BorderRadius borderRadius;
 

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -147,8 +147,7 @@ class _PinCodeVerificationScreenState extends State<PinCodeVerificationScreen> {
                         borderRadius: BorderRadius.circular(5),
                         fieldHeight: 50,
                         fieldWidth: 40,
-                        activeFillColor:
-                            hasError ? Colors.blue.shade100 : Colors.white,
+                        activeFillColor: Colors.white,
                       ),
                       cursorColor: Colors.black,
                       animationDuration: Duration(milliseconds: 300),
@@ -229,12 +228,9 @@ class _PinCodeVerificationScreenState extends State<PinCodeVerificationScreen> {
                       if (currentText.length != 6 || currentText != "123456") {
                         errorController!.add(ErrorAnimationType
                             .shake); // Triggering error shake animation
-                        setState(() {
-                          hasError = true;
-                        });
+                        setState(() => hasError = true);
                       } else {
-                        setState(
-                          () {
+                        setState(() {
                             hasError = false;
                             snackBar("OTP Verified!!");
                           },

--- a/lib/src/models/pin_theme.dart
+++ b/lib/src/models/pin_theme.dart
@@ -22,6 +22,9 @@ class PinTheme {
   /// Colors of the input fields which don't have inputs. Default is [Colors.red]
   final Color inactiveFillColor;
 
+  /// Color of the input field when in error mode. Default is [Colors.redAccent]
+  final Color errorBorderColor;
+
   /// Border radius of each pin code field
   final BorderRadius borderRadius;
 
@@ -54,6 +57,7 @@ class PinTheme {
     this.activeFillColor = Colors.green,
     this.selectedFillColor = Colors.blue,
     this.inactiveFillColor = Colors.red,
+    this.errorBorderColor = Colors.redAccent,
   });
 
   factory PinTheme(
@@ -64,6 +68,7 @@ class PinTheme {
       Color? activeFillColor,
       Color? selectedFillColor,
       Color? inactiveFillColor,
+      Color? errorBorderColor,
       BorderRadius? borderRadius,
       double? fieldHeight,
       double? fieldWidth,
@@ -91,6 +96,9 @@ class PinTheme {
       inactiveFillColor: inactiveFillColor == null
           ? defaultValues.inactiveFillColor
           : inactiveFillColor,
+      errorBorderColor: errorBorderColor == null
+        ? defaultValues.errorBorderColor
+        : errorBorderColor,
       selectedColor:
           selectedColor == null ? defaultValues.selectedColor : selectedColor,
       selectedFillColor: selectedFillColor == null

--- a/lib/src/pin_code_fields.dart
+++ b/lib/src/pin_code_fields.dart
@@ -250,6 +250,7 @@ class _PinCodeTextFieldState extends State<PinCodeTextField>
   late AnimationController _cursorController;
 
   StreamSubscription<ErrorAnimationType>? _errorAnimationSubscription;
+  bool isInErrorMode = false;
 
   // Animation for the error animation
   late Animation<Offset> _offsetAnimation;
@@ -327,6 +328,7 @@ class _PinCodeTextFieldState extends State<PinCodeTextField>
           widget.errorAnimationController!.stream.listen((errorAnimation) {
         if (errorAnimation == ErrorAnimationType.shake) {
           _controller.forward();
+          setState(() => isInErrorMode = true);
         }
       });
     }
@@ -390,6 +392,10 @@ class _PinCodeTextFieldState extends State<PinCodeTextField>
     _textEditingController?.addListener(() {
       if (widget.useHapticFeedback) {
         runHapticFeedback();
+      }
+
+      if (isInErrorMode) {
+        setState(() => isInErrorMode = false);
       }
 
       _debounceBlink();
@@ -468,9 +474,14 @@ class _PinCodeTextFieldState extends State<PinCodeTextField>
         _focusNode!.hasFocus) {
       return _pinTheme.selectedColor;
     } else if (_selectedIndex > index) {
-      return _pinTheme.activeColor;
+      Color relevantActiveColor = _pinTheme.activeColor;
+      if (isInErrorMode) relevantActiveColor = _pinTheme.errorBorderColor;
+      return relevantActiveColor;
     }
-    return _pinTheme.inactiveColor;
+
+    Color relevantInActiveColor = _pinTheme.inactiveColor;
+    if (isInErrorMode) relevantInActiveColor = _pinTheme.errorBorderColor;
+    return relevantInActiveColor;
   }
 
   Widget _renderPinField({


### PR DESCRIPTION
This pull request contains a feature request from here: https://github.com/adar2378/pin_code_fields/issues/174
The current implementation changes both `activeColor` & `inactiveColor` when an error is triggered.

Usage is as simple as defining `errorBorderColor` in the `PinTheme`.
