### PR TITLE
Always add `errorTextSpace`

### DIFF
--- a/lib/src/pin_code_fields.dart
+++ b/lib/src/pin_code_fields.dart
@@ -752,9 +752,7 @@ class _PinCodeTextFieldState extends State<PinCodeTextField>
       position: _offsetAnimation,
       child: Container(
         // adding the extra space at the bottom to show the error text from validator
-        height: widget.autovalidateMode == AutovalidateMode.disabled
-            ? widget.pinTheme.fieldHeight
-            : widget.pinTheme.fieldHeight + widget.errorTextSpace,
+        height: widget.pinTheme.fieldHeight + widget.errorTextSpace,
         color: widget.backgroundColor,
         child: Stack(
           alignment: Alignment.bottomCenter,


### PR DESCRIPTION
A fix for [this comment](https://github.com/adar2378/pin_code_fields/issues/188#issuecomment-922908218) (broken error text padding when validation is called manually)