### PR TITLE
Add row direction

### DIFF
--- a/lib/src/pin_code_fields.dart
+++ b/lib/src/pin_code_fields.dart
@@ -793,6 +793,7 @@ class _PinCodeTextFieldState extends State<PinCodeTextField>
                       }
                     : null,
                 child: Row(
+                  textDirection: TextDirection.ltr,
                   mainAxisAlignment: widget.mainAxisAlignment,
                   children: _generateFields(),
                 ),


### PR DESCRIPTION
In case app uses RTL layout, the fields displayed in reverse order.
This fix force the row to be LTR direction.
(Maybe it will be good idea to add an optional parmeter to achieve this)