### PR TITLE
optionally obscure text

### DIFF
--- a/lib/src/pin_code_fields.dart
+++ b/lib/src/pin_code_fields.dart
@@ -765,6 +765,7 @@ class _PinCodeTextFieldState extends State<PinCodeTextField>
           scrollPadding: widget.scrollPadding,
           readOnly: widget.readOnly,
           obscureText: widget.obscureText,
+          enableSuggestions: false,
         ),
       ),
     );

--- a/lib/src/pin_code_fields.dart
+++ b/lib/src/pin_code_fields.dart
@@ -764,6 +764,7 @@ class _PinCodeTextFieldState extends State<PinCodeTextField>
           ),
           scrollPadding: widget.scrollPadding,
           readOnly: widget.readOnly,
+          obscureText: widget.obscureText,
         ),
       ),
     );

--- a/lib/src/pin_code_fields.dart
+++ b/lib/src/pin_code_fields.dart
@@ -765,7 +765,6 @@ class _PinCodeTextFieldState extends State<PinCodeTextField>
           scrollPadding: widget.scrollPadding,
           readOnly: widget.readOnly,
           obscureText: widget.obscureText,
-          enableSuggestions: false,
         ),
       ),
     );


### PR DESCRIPTION
Hey there,

is there any reason the obscureText flag is not handed down to the TextFormField? - I had the problem, that my "obscured" textfields were showing a plaintext copy of the inserted PIN above the keyboard. So e.g. when I entered ABC as *** in the Widget, there was a suggestion shown for ios on the simulator and the device which contained the ABC as readable text. Pretty strange security related issue. While this issue seems to be a more general one. It seems to be solvable by setting the obscureText flag to true.

Maybe this has unwanted sideeffects im currently not aware of yet.
E.g. whenever i enter something with the obscureText flag active, I am presented with the "Keychain" Option in the suggestion bar...