### PR TITLE
Added mounted checks to prevent setState call.

### DIFF
--- a/lib/src/pin_code_fields.dart
+++ b/lib/src/pin_code_fields.dart
@@ -333,7 +333,9 @@ class _PinCodeTextFieldState extends State<PinCodeTextField>
     }
     _focusNode = widget.focusNode ?? FocusNode();
     _focusNode!.addListener(() {
-      setState(() {});
+      if(mounted) {
+        setState(() {});
+      }
     }); // Rebuilds on every change to reflect the correct color on each field.
     _inputList = List<String>.filled(widget.length, "");
 
@@ -374,7 +376,9 @@ class _PinCodeTextFieldState extends State<PinCodeTextField>
           widget.errorAnimationController!.stream.listen((errorAnimation) {
         if (errorAnimation == ErrorAnimationType.shake) {
           _controller.forward();
-          setState(() => isInErrorMode = true);
+          if(mounted) {
+            setState(() => isInErrorMode = true);
+          }
         }
       });
     }
@@ -440,7 +444,7 @@ class _PinCodeTextFieldState extends State<PinCodeTextField>
         runHapticFeedback();
       }
 
-      if (isInErrorMode) {
+      if (mounted && isInErrorMode) {
         setState(() => isInErrorMode = false);
       }
 
@@ -475,9 +479,11 @@ class _PinCodeTextFieldState extends State<PinCodeTextField>
     if (widget.blinkWhenObscuring &&
         _textEditingController!.text.length >
             _inputList.where((x) => x.isNotEmpty).length) {
-      setState(() {
-        _hasBlinked = false;
-      });
+      if(mounted) {
+        setState(() {
+          _hasBlinked = false;
+        });
+      }
 
       if (_blinkDebounce?.isActive ?? false) {
         _blinkDebounce!.cancel();


### PR DESCRIPTION
Added mounted checks to prevent setState call if the widget has been disposed of.

I've been getting the following error on the latest version `7.4.0`. 

Logs: 
```flutter: setState() called after dispose(): _PinCodeTextFieldState#cde85(lifecycle state: defunct, not mounted, tickers: tracking 0 tickers)
This error happens if you call setState() on a State object for a widget that no longer appears in the widget tree (e.g., whose parent widget no longer includes the widget in its build). This error can occur when code calls setState() from a timer or an animation callback.
The preferred solution is to cancel the timer or stop listening to the animation in the dispose() callback. Another solution is to check the "mounted" property of this object before calling setState() to ensure the object is still in the tree.
This error might indicate a memory leak if setState() is being called because another object is retaining a reference to this State object after it has been removed from the tree. To avoid memory leaks, consider breaking the reference to this object during dispose().
flutter: 
#0      State.setState.<anonymous closure> (package:flutter/src/widgets/framework.dart:1073:9)
#1      State.setState (package:flutter/src/widgets/framework.dart:1108:6)
#2      _PinCodeTextFieldState._debounceBlink (package:pin_code_fields/src/pin_code_fields.dart:478:7)
#3      _PinCodeTextFieldState._assignController.<anonymous closure> (package:pin_code_fields/src/pin_code_fields.dart:447:7)
#4      ChangeNotifier.notifyListeners (package:flutter/src/foundation/change_notifier.dart:324:24)
#5      ValueNotifier.value= (package:flutter/src/foundation/change_notifier.dart:428:5)
#6      TextEditingController.value= (package:flutter/src/widgets/editable_text.dart:159:11)
#7      EditableTextState._value= (package:flutter/src/widgets/editable_text.dart:2211:23)```