### PR TITLE
chore: make onChanged nullable

### DIFF
--- a/lib/src/pin_code_fields.dart
+++ b/lib/src/pin_code_fields.dart
@@ -46,7 +46,7 @@ class PinCodeTextField extends StatefulWidget {
   final Duration blinkDuration;
 
   /// returns the current typed text in the fields
-  final ValueChanged<String> onChanged;
+  final ValueChanged<String>? onChanged;
 
   /// returns the typed text when all pins are set
   final ValueChanged<String>? onCompleted;
@@ -211,7 +211,7 @@ class PinCodeTextField extends StatefulWidget {
     this.obscuringWidget,
     this.blinkWhenObscuring = false,
     this.blinkDuration = const Duration(milliseconds: 500),
-    required this.onChanged,
+    this.onChanged,
     this.onCompleted,
     this.backgroundColor,
     this.mainAxisAlignment = MainAxisAlignment.spaceBetween,
@@ -462,7 +462,7 @@ class _PinCodeTextFieldState extends State<PinCodeTextField>
 
           if (widget.autoDismissKeyboard) _focusNode!.unfocus();
         }
-        widget.onChanged(currentText);
+        widget.onChanged?.call(currentText);
       }
 
       _setTextToInput(currentText);

--- a/test/pin_code_fields_test.dart
+++ b/test/pin_code_fields_test.dart
@@ -19,7 +19,6 @@ void main() {
           body: PinCodeTextField(
             appContext: context,
             length: 6,
-            onChanged: (input) {},
             errorAnimationController: controller,
           ),
         ),
@@ -58,7 +57,6 @@ void main() {
                 backgroundColor: Colors.transparent,
                 length: 6,
                 animationDuration: Duration.zero,
-                onChanged: (input) {},
               );
             }),
           ),


### PR DESCRIPTION
Hey, @adar2378 
Thanks for the lib!

Sometimes we don't need any callbacks on value changed (e.g. in the tests).
So, I suggest to make `onChanged` field nullable.