### PR TITLE
fix: linting and dart immutable issues

### DIFF
--- a/lib/src/pin_code_fields.dart
+++ b/lib/src/pin_code_fields.dart
@@ -62,7 +62,7 @@ class PinCodeTextField extends StatefulWidget {
   ///
   /// Set this to empty function if you don't want the keyboard to automatically close
   /// when user presses done/next.
-  VoidCallback? onEditingComplete;
+  final VoidCallback? onEditingComplete;
 
   /// the style of the text, default is [ fontSize: 20, fontWeight: FontWeight.bold]
   final TextStyle? textStyle;
@@ -446,7 +446,7 @@ class _PinCodeTextFieldState extends State<PinCodeTextField>
 
   // Assigning the text controller, if empty assigning a new one.
   void _assignController() {
-      _textEditingController =  widget.controller ?? TextEditingController();
+    _textEditingController = widget.controller ?? TextEditingController();
 
     _textEditingController?.addListener(() {
       if (widget.useHapticFeedback) {

--- a/test/pin_code_fields_test.dart
+++ b/test/pin_code_fields_test.dart
@@ -5,9 +5,7 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:pin_code_fields/pin_code_fields.dart';
 
 void main() {
-  final TestWidgetsFlutterBinding binding =
-      TestWidgetsFlutterBinding.ensureInitialized()
-          as TestWidgetsFlutterBinding;
+  final binding = TestWidgetsFlutterBinding.ensureInitialized();
 
   testWidgets('disposes error stream', (WidgetTester tester) async {
     final StreamController<ErrorAnimationType> controller =


### PR DESCRIPTION
## Fixes

- Unnecessary type casting casting
- PinCodeTextField is marked as `@immutable`, but one or more of its instance fields aren't final: _PinCodeTextField.onEditingComplete_

## Changes

Formatted code according to dart standards