### PR TITLE
feat!: exposing platform enum to use directly

### DIFF
--- a/lib/pin_code_fields.dart
+++ b/lib/pin_code_fields.dart
@@ -9,11 +9,11 @@ import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:pin_code_fields/src/cursor_painter.dart';
-import 'package:pin_code_fields/src/models/platform.dart';
 
 part 'src/models/haptic_feedback_type.dart';
 part 'src/models/animation_type.dart';
 part 'src/models/dialog_config.dart';
 part 'src/models/pin_theme.dart';
+part 'src/models/pin_code_platform.dart';
 part 'src/pin_code_fields.dart';
 part 'src/gradiented.dart';

--- a/lib/src/models/dialog_config.dart
+++ b/lib/src/models/dialog_config.dart
@@ -14,13 +14,13 @@ class DialogConfig {
   final String? negativeText;
 
   /// The default dialog theme, should it be iOS or other(including web and Android)
-  final Platform platform;
+  final PinCodePlatform platform;
   DialogConfig._internal({
     this.dialogContent,
     this.dialogTitle,
     this.affirmativeText,
     this.negativeText,
-    this.platform = Platform.other,
+    this.platform = PinCodePlatform.other,
   });
 
   factory DialogConfig({
@@ -28,7 +28,7 @@ class DialogConfig {
     String? dialogContent,
     String? dialogTitle,
     String? negativeText,
-    Platform? platform,
+    PinCodePlatform? platform,
   }) {
     return DialogConfig._internal(
       affirmativeText: affirmativeText == null ? "Paste" : affirmativeText,
@@ -37,7 +37,7 @@ class DialogConfig {
           : dialogContent,
       dialogTitle: dialogTitle == null ? "Paste Code" : dialogTitle,
       negativeText: negativeText == null ? "Cancel" : negativeText,
-      platform: platform == null ? Platform.other : platform,
+      platform: platform == null ? PinCodePlatform.other : platform,
     );
   }
 }

--- a/lib/src/models/pin_code_platform.dart
+++ b/lib/src/models/pin_code_platform.dart
@@ -1,0 +1,15 @@
+part of pin_code_fields;
+
+enum PinCodePlatform {
+  /// Using this enum value will make the use of [Cupertino Alert Dialog] while
+  /// showing paste dialog.
+  ///
+  /// [Cupertino Alert Dialog]: https://api.flutter.dev/flutter/cupertino/CupertinoAlertDialog-class.html
+  iOS,
+
+  /// Using this enum value will make the use of [Material Alert Dialog] while
+  /// showing paste dialog.
+  ///
+  /// [Material Alert Dialog]: https://api.flutter.dev/flutter/material/AlertDialog-class.html
+  other,
+}

--- a/lib/src/models/platform.dart
+++ b/lib/src/models/platform.dart
@@ -1,1 +1,0 @@
-enum Platform { iOS, other } //other indicates for web and android

--- a/lib/src/pin_code_fields.dart
+++ b/lib/src/pin_code_fields.dart
@@ -446,7 +446,7 @@ class _PinCodeTextFieldState extends State<PinCodeTextField>
 
   // Assigning the text controller, if empty assigning a new one.
   void _assignController() {
-      _textEditingController =  widget.controller ?? TextEditingController();
+    _textEditingController = widget.controller ?? TextEditingController();
 
     _textEditingController?.addListener(() {
       if (widget.useHapticFeedback) {
@@ -680,7 +680,7 @@ class _PinCodeTextFieldState extends State<PinCodeTextField>
     return showDialog(
       context: context,
       useRootNavigator: true,
-      builder: (context) => _dialogConfig.platform == Platform.iOS
+      builder: (context) => _dialogConfig.platform == PinCodePlatform.iOS
           ? CupertinoAlertDialog(
               title: Text(_dialogConfig.dialogTitle!),
               content: RichText(
@@ -953,7 +953,7 @@ class _PinCodeTextFieldState extends State<PinCodeTextField>
 
   List<Widget> _getActionButtons(String pastedText) {
     var resultList = <Widget>[];
-    if (_dialogConfig.platform == Platform.iOS) {
+    if (_dialogConfig.platform == PinCodePlatform.iOS) {
       resultList.addAll([
         CupertinoDialogAction(
           child: Text(_dialogConfig.negativeText!),


### PR DESCRIPTION
# This PR contains BREAKING CHANGES

### Breaking Changes

- Changed enum name to `PinCodePlatform` from `Platform`
- Making `PinCodePlatform` part of `pin_code_fields` library ultimately exposing enum to direct use from import:
```dart
import 'package:pin_code_fields/pin_code_fields.dart';
```

### Changes

- Added proper docs explaining the use of values from the `PinCodePlatform` enum

resolves #316, resolves #108