### PR TITLE
fix: Platform.iOS does not show cupertino dialog

### DIFF
--- a/lib/src/pin_code_fields.dart
+++ b/lib/src/pin_code_fields.dart
@@ -316,6 +316,7 @@ class _PinCodeTextFieldState extends State<PinCodeTextField>
           dialogContent: widget.dialogConfig!.dialogContent,
           dialogTitle: widget.dialogConfig!.dialogTitle,
           negativeText: widget.dialogConfig!.negativeText,
+          platform: widget.dialogConfig!.platform,
         );
   PinTheme get _pinTheme => widget.pinTheme;
 
@@ -446,7 +447,7 @@ class _PinCodeTextFieldState extends State<PinCodeTextField>
 
   // Assigning the text controller, if empty assigning a new one.
   void _assignController() {
-      _textEditingController =  widget.controller ?? TextEditingController();
+    _textEditingController = widget.controller ?? TextEditingController();
 
     _textEditingController?.addListener(() {
       if (widget.useHapticFeedback) {


### PR DESCRIPTION
| With `Platform.iOS` | With `Platform.other` |
|---------------------|-----------------------|
| <img width="430" alt="Screenshot 2023-01-27 at 1 27 46 AM" src="https://user-images.githubusercontent.com/74326345/214939242-765fdc2e-b21c-46ac-9d0d-0647eca376a2.png"> | <img width="446" alt="Screenshot 2023-01-27 at 1 28 19 AM" src="https://user-images.githubusercontent.com/74326345/214939170-1cee3dd5-b3fd-4aa0-8caf-b8fdf762e73b.png"> |

resolves #318 