### PR TITLE
fix:remove error-border from TextFormField

### DIFF
--- a/lib/src/pin_code_fields.dart
+++ b/lib/src/pin_code_fields.dart
@@ -776,6 +776,8 @@ class _PinCodeTextFieldState extends State<PinCodeTextField>
             enabledBorder: InputBorder.none,
             focusedBorder: InputBorder.none,
             disabledBorder: InputBorder.none,
+            errorBorder: InputBorder.none,
+            focusedErrorBorder: InputBorder.none,
           ),
           style: TextStyle(
             color: Colors.transparent,


### PR DESCRIPTION
I fixed error border at TextFormField in  PinCodeTextField.
If inputDecoration of theme is setted, like under picture, unncessary error border is shown when validator is called.

![flutter_01](https://user-images.githubusercontent.com/83831465/233013345-3148eb3a-b058-4d6e-81d6-54be225de0ae.png)
