### PR TITLE
Allow to paste the code without showing a popup 🤝

### DIFF
--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -43,6 +43,7 @@ class PinCodeVerificationScreen extends StatefulWidget {
 
 class _PinCodeVerificationScreenState extends State<PinCodeVerificationScreen> {
   TextEditingController textEditingController = TextEditingController();
+
   // ..text = "123456";
 
   // ignore: close_sinks
@@ -145,6 +146,7 @@ class _PinCodeVerificationScreenState extends State<PinCodeVerificationScreen> {
                     ),
                     length: 6,
                     obscureText: true,
+                    showPopup: false,
                     obscuringCharacter: '*',
                     obscuringWidget: const FlutterLogo(
                       size: 24,

--- a/lib/src/pin_code_fields.dart
+++ b/lib/src/pin_code_fields.dart
@@ -14,6 +14,9 @@ class PinCodeTextField extends StatefulWidget {
   /// you already know what it does i guess :P default is false
   final bool obscureText;
 
+  /// When you want to paste your code without shown the popup, make it false
+  final bool showPopup;
+
   /// Character used for obscuring text if obscureText is true.
   ///
   /// Must not be empty. Single character is recommended.
@@ -220,6 +223,7 @@ class PinCodeTextField extends StatefulWidget {
     required this.length,
     this.controller,
     this.obscureText = false,
+    this.showPopup = true,
     this.obscuringCharacter = '●',
     this.obscuringWidget,
     this.blinkWhenObscuring = false,
@@ -309,6 +313,7 @@ class _PinCodeTextFieldState extends State<PinCodeTextField>
   late Animation<Offset> _offsetAnimation;
 
   late Animation<double> _cursorAnimation;
+
   DialogConfig get _dialogConfig => widget.dialogConfig == null
       ? DialogConfig()
       : DialogConfig(
@@ -318,6 +323,7 @@ class _PinCodeTextFieldState extends State<PinCodeTextField>
           negativeText: widget.dialogConfig!.negativeText,
           platform: widget.dialogConfig!.platform,
         );
+
   PinTheme get _pinTheme => widget.pinTheme;
 
   Timer? _blinkDebounce;
@@ -854,12 +860,16 @@ class _PinCodeTextFieldState extends State<PinCodeTextField>
                     ? () async {
                         var data = await Clipboard.getData("text/plain");
                         if (data?.text?.isNotEmpty ?? false) {
-                          if (widget.beforeTextPaste != null) {
-                            if (widget.beforeTextPaste!(data!.text)) {
-                              _showPasteDialog(data.text!);
-                            }
+                          if (!widget.showPopup) {
+                            _textEditingController!.text = data!.text!;
                           } else {
-                            _showPasteDialog(data!.text!);
+                            if (widget.beforeTextPaste != null) {
+                              if (widget.beforeTextPaste!(data!.text)) {
+                                _showPasteDialog(data.text!);
+                              }
+                            } else {
+                              _showPasteDialog(data!.text!);
+                            }
                           }
                         }
                       }


### PR DESCRIPTION
**In this PR,**
You can paste your code **without showing the popup**!

**How?**
I added a new attribute called "`showPopup`" and the default value is true.
When assigning false to this value, and pasting the code, the popup is not appear. 

Check the video, please.

https://github.com/adar2378/pin_code_fields/assets/60509531/9d1d17f5-5569-4e0d-8990-9aac5cdfdb9c

