### PR TITLE
Improve focus logic on Android

### DIFF
--- a/README.md
+++ b/README.md
@@ -244,9 +244,6 @@ A flutter package which will help you to generate pin code fields with beautiful
   /// Makes the pin cells readOnly
   final bool readOnly;
 
-  /// Enable auto unfocus
-  final bool autoUnfocus;
-
   /// Builds separator children
   final IndexedWidgetBuilder? separatorBuilder;
 ```

--- a/lib/src/pin_code_fields.dart
+++ b/lib/src/pin_code_fields.dart
@@ -208,9 +208,6 @@ class PinCodeTextField extends StatefulWidget {
   /// Makes the pin cells readOnly
   final bool readOnly;
 
-  /// Enable auto unfocus
-  final bool autoUnfocus;
-
   /// Builds separator children
   final IndexedWidgetBuilder? separatorBuilder;
 
@@ -270,7 +267,6 @@ class PinCodeTextField extends StatefulWidget {
     this.hintStyle,
     this.textGradient,
     this.readOnly = false,
-    this.autoUnfocus = false,
 
     /// Default for [AutofillGroup]
     this.onAutoFillDisposeAction = AutofillContextAction.commit,
@@ -954,28 +950,15 @@ class _PinCodeTextFieldState extends State<PinCodeTextField>
   }
 
   void _onFocus() {
-    if (widget.autoUnfocus) {
-      if (_focusNode!.hasFocus &&
-          MediaQuery.of(widget.appContext).viewInsets.bottom == 0) {
-        _focusNode!.unfocus();
-        Future.delayed(
-          const Duration(microseconds: 1),
-          () => _focusNode!.requestFocus(),
-        );
-      } else {
-        _focusNode!.requestFocus();
-      }
+    if (_focusNode!.hasFocus &&
+        MediaQuery.of(widget.appContext).viewInsets.bottom == 0) {
+      _focusNode!.unfocus();
+      Future.delayed(
+        const Duration(microseconds: 1),
+            () => _focusNode!.requestFocus(),
+      );
     } else {
-      if (_focusNode!.hasFocus &&
-          MediaQuery.of(widget.appContext).viewInsets.bottom == 0) {
-        _focusNode!.unfocus();
-        Future.delayed(
-          const Duration(microseconds: 1),
-              () => _focusNode!.requestFocus(),
-        );
-      } else {
-        _focusNode!.requestFocus();
-      }
+      _focusNode!.requestFocus();
     }
   }
 

--- a/lib/src/pin_code_fields.dart
+++ b/lib/src/pin_code_fields.dart
@@ -270,7 +270,7 @@ class PinCodeTextField extends StatefulWidget {
     this.hintStyle,
     this.textGradient,
     this.readOnly = false,
-    this.autoUnfocus = true,
+    this.autoUnfocus = false,
 
     /// Default for [AutofillGroup]
     this.onAutoFillDisposeAction = AutofillContextAction.commit,
@@ -309,6 +309,7 @@ class _PinCodeTextFieldState extends State<PinCodeTextField>
   late Animation<Offset> _offsetAnimation;
 
   late Animation<double> _cursorAnimation;
+
   DialogConfig get _dialogConfig => widget.dialogConfig == null
       ? DialogConfig()
       : DialogConfig(
@@ -318,6 +319,7 @@ class _PinCodeTextFieldState extends State<PinCodeTextField>
           negativeText: widget.dialogConfig!.negativeText,
           platform: widget.dialogConfig!.platform,
         );
+
   PinTheme get _pinTheme => widget.pinTheme;
 
   Timer? _blinkDebounce;
@@ -957,12 +959,23 @@ class _PinCodeTextFieldState extends State<PinCodeTextField>
           MediaQuery.of(widget.appContext).viewInsets.bottom == 0) {
         _focusNode!.unfocus();
         Future.delayed(
-            const Duration(microseconds: 1), () => _focusNode!.requestFocus());
+          const Duration(microseconds: 1),
+          () => _focusNode!.requestFocus(),
+        );
       } else {
         _focusNode!.requestFocus();
       }
     } else {
-      _focusNode!.requestFocus();
+      if (_focusNode!.hasFocus &&
+          MediaQuery.of(widget.appContext).viewInsets.bottom == 0) {
+        _focusNode!.unfocus();
+        Future.delayed(
+          const Duration(microseconds: 1),
+              () => _focusNode!.requestFocus(),
+        );
+      } else {
+        _focusNode!.requestFocus();
+      }
     }
   }
 


### PR DESCRIPTION
- related issue: #262 
- related PR: https://github.com/adar2378/pin_code_fields/pull/242

## Description

On android, there is a keyboard issue when `PinCodeTextField.autoUnfocus` is `false` and app becomes background with focusNode active like this demo.

https://github.com/adar2378/pin_code_fields/assets/44002126/64b28aff-a108-4fec-b1ef-bb1d96b8c144

To fix this issue, I need to use same logic as `PinCodeTextField.autoUnfocus` is `true` which is introduced in https://github.com/adar2378/pin_code_fields/pull/242.

## What I did

I deleted `autoUnfocus` property, because it can be better to fix as `true`.


