### PR TITLE
Expose textScaler

### DIFF
--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -43,6 +43,7 @@ class PinCodeVerificationScreen extends StatefulWidget {
 
 class _PinCodeVerificationScreenState extends State<PinCodeVerificationScreen> {
   TextEditingController textEditingController = TextEditingController();
+
   // ..text = "123456";
 
   // ignore: close_sinks
@@ -216,9 +217,11 @@ class _PinCodeVerificationScreenState extends State<PinCodeVerificationScreen> {
               Row(
                 mainAxisAlignment: MainAxisAlignment.center,
                 children: [
-                  const Text(
-                    "Didn't receive the code? ",
-                    style: TextStyle(color: Colors.black54, fontSize: 15),
+                  const Flexible(
+                    child: Text(
+                      "Didn't receive the code? ",
+                      style: TextStyle(color: Colors.black54, fontSize: 15),
+                    ),
                   ),
                   TextButton(
                     onPressed: () => snackBar("OTP resend!!"),

--- a/lib/src/pin_code_fields.dart
+++ b/lib/src/pin_code_fields.dart
@@ -67,6 +67,9 @@ class PinCodeTextField extends StatefulWidget {
   /// the style of the text, default is [ fontSize: 20, fontWeight: FontWeight.bold]
   final TextStyle? textStyle;
 
+  /// [TextScaler] for pin code field and hint text.
+  final TextScaler? textScaler;
+
   /// the style of the pasted text, default is [fontWeight: FontWeight.bold] while
   /// [TextStyle.color] is [ThemeData.colorScheme.onSecondary]
   final TextStyle? pastedTextStyle;
@@ -238,6 +241,7 @@ class PinCodeTextField extends StatefulWidget {
     this.enabled = true,
     this.inputFormatters = const <TextInputFormatter>[],
     this.textStyle,
+    this.textScaler,
     this.useHapticFeedback = false,
     this.hapticFeedbackTypes = HapticFeedbackTypes.light,
     this.pastedTextStyle,
@@ -309,6 +313,7 @@ class _PinCodeTextFieldState extends State<PinCodeTextField>
   late Animation<Offset> _offsetAnimation;
 
   late Animation<double> _cursorAnimation;
+
   DialogConfig get _dialogConfig => widget.dialogConfig == null
       ? DialogConfig()
       : DialogConfig(
@@ -318,6 +323,7 @@ class _PinCodeTextFieldState extends State<PinCodeTextField>
           negativeText: widget.dialogConfig!.negativeText,
           platform: widget.dialogConfig!.platform,
         );
+
   PinTheme get _pinTheme => widget.pinTheme;
 
   Timer? _blinkDebounce;
@@ -601,6 +607,7 @@ class _PinCodeTextFieldState extends State<PinCodeTextField>
         widget.hintCharacter!,
         key: ValueKey(_inputList[index]),
         style: _hintStyle,
+        textScaler: widget.textScaler,
       );
     }
 
@@ -615,12 +622,14 @@ class _PinCodeTextFieldState extends State<PinCodeTextField>
               text,
               key: ValueKey(_inputList[index]),
               style: _textStyle.copyWith(color: Colors.white),
+              textScaler: widget.textScaler,
             ),
           )
         : Text(
             text,
             key: ValueKey(_inputList[index]),
             style: _textStyle,
+            textScaler: widget.textScaler,
           );
   }
 


### PR DESCRIPTION
Accessibility text sizes in system settings are currently not really supported by `PinCodeTextField`: The field does not resize to accommodate very large text, which is thus clipped. Currently a workaround for this was to set `fontSize` in the `textStyle` to the intended font size (20.0, usually) divided by the `textScaleFactor`, such that fontSize * textScaleFactor would yield 20.0. With the introduction of `TextScaler` and deprecation of `textScaleFactor` in the latest Flutter versions this is no longer a viable solution. (In mathematical terms: The mentioned workaround uses the multiplicative inverse of `textScaleFactor`, while with the potentially nonlinear `textScaler` an inverse is difficult to find and not guaranteed to exist.)

Thus, expose `textScaler` of the `PinCodeTextField` to allow setting it to `TextScaler.noScaling`. (This PR does not include a scaling for the validator as I'm not sure how to do this and do not need it.) 

To test, just add 
```
                    textScaler: TextScaler.noScaling,
                    hintCharacter: "1",
```
in the `PinCodeTextField` of the example app and run on a device where in system settings you set font size to the maximum (preferrably iOS, which allows more radical sizes than Android, at least on the devices I tested). Tested with Flutter 3.16.0.

P.S.: You may need to upgrade deployment targets or Gradle version for the example app.