### PR TITLE
Border width as default

### DIFF
--- a/lib/src/models/pin_theme.dart
+++ b/lib/src/models/pin_theme.dart
@@ -31,13 +31,13 @@ class PinTheme {
   /// Width of the input field which is currently selected. Default is 2
   final double selectedBorderWidth;
 
-    /// Width of the input fields which don't have inputs. Default is 2
+  /// Width of the input fields which don't have inputs. Default is 2
   final double inactiveBorderWidth;
 
   /// Width of the input fields if the [PinCodeTextField] is disabled. Default is 2
   final double disabledBorderWidth;
 
-    /// Width of the input field when in error mode. Default is 2
+  /// Width of the input field when in error mode. Default is 2
   final double errorBorderWidth;
 
   /// Border radius of each pin code field
@@ -50,7 +50,7 @@ class PinTheme {
   final double fieldWidth;
 
   /// Border width for the each input fields. Default is [2.0]
-  final double borderWidth;
+  final double? borderWidth;
 
   /// this defines the shape of the input fields. Default is underlined
   final PinCodeFieldShape shape;
@@ -68,7 +68,7 @@ class PinTheme {
     this.borderRadius = BorderRadius.zero,
     this.fieldHeight = 50,
     this.fieldWidth = 40,
-    this.borderWidth = 2,
+    this.borderWidth,
     this.fieldOuterPadding = EdgeInsets.zero,
     this.shape = PinCodeFieldShape.underline,
     this.activeColor = Colors.green,
@@ -116,7 +116,7 @@ class PinTheme {
       activeColor: activeColor ?? defaultValues.activeColor,
       activeFillColor: activeFillColor ?? defaultValues.activeFillColor,
       borderRadius: borderRadius ?? defaultValues.borderRadius,
-      borderWidth: borderWidth ?? defaultValues.borderWidth,
+      borderWidth: borderWidth ?? null,
       disabledColor: disabledColor ?? defaultValues.disabledColor,
       fieldHeight: fieldHeight ?? defaultValues.fieldHeight,
       fieldWidth: fieldWidth ?? defaultValues.fieldWidth,
@@ -131,12 +131,12 @@ class PinTheme {
       inActiveBoxShadows: inActiveBoxShadow ?? [],
       activeBorderWidth: activeBorderWidth ?? defaultValues.activeBorderWidth,
       inactiveBorderWidth:
-          inactiveBorderWidth ?? defaultValues.inactiveBorderWidth,
+      inactiveBorderWidth ?? borderWidth ?? defaultValues.inactiveBorderWidth,
       selectedBorderWidth:
-          selectedBorderWidth ?? defaultValues.selectedBorderWidth,
-      errorBorderWidth: errorBorderWidth ?? defaultValues.errorBorderWidth,
+      selectedBorderWidth ?? borderWidth ?? defaultValues.selectedBorderWidth,
+      errorBorderWidth: errorBorderWidth ?? borderWidth ?? defaultValues.errorBorderWidth,
       disabledBorderWidth:
-          disabledBorderWidth ?? defaultValues.disabledBorderWidth,
+      disabledBorderWidth ?? borderWidth ?? defaultValues.disabledBorderWidth,
     );
   }
 }

--- a/lib/src/models/pin_theme.dart
+++ b/lib/src/models/pin_theme.dart
@@ -25,19 +25,19 @@ class PinTheme {
   /// Color of the input field when in error mode. Default is [Colors.redAccent]
   final Color errorBorderColor;
 
-  /// Width of the input fields which have inputs. Default is 2
+  /// Width of the input fields which have inputs. Default is 2 or [borderWidth] if set
   final double activeBorderWidth;
 
-  /// Width of the input field which is currently selected. Default is 2
+  /// Width of the input field which is currently selected. Default is 2 or [borderWidth] if set
   final double selectedBorderWidth;
 
-  /// Width of the input fields which don't have inputs. Default is 2
+  /// Width of the input fields which don't have inputs. Default is 2 or [borderWidth] if set
   final double inactiveBorderWidth;
 
   /// Width of the input fields if the [PinCodeTextField] is disabled. Default is 2
   final double disabledBorderWidth;
 
-  /// Width of the input field when in error mode. Default is 2
+  /// Width of the input field when in error mode. Default is 2 or [borderWidth] if set
   final double errorBorderWidth;
 
   /// Border radius of each pin code field
@@ -49,7 +49,7 @@ class PinTheme {
   /// [width] for the pin code field. default is [40.0]
   final double fieldWidth;
 
-  /// Border width for the each input fields. Default is [2.0]
+  /// Border width for each input fields. Can be overridden by the individual widths.
   final double? borderWidth;
 
   /// this defines the shape of the input fields. Default is underlined

--- a/lib/src/pin_code_fields.dart
+++ b/lib/src/pin_code_fields.dart
@@ -312,25 +312,25 @@ class _PinCodeTextFieldState extends State<PinCodeTextField>
   DialogConfig get _dialogConfig => widget.dialogConfig == null
       ? DialogConfig()
       : DialogConfig(
-          affirmativeText: widget.dialogConfig!.affirmativeText,
-          dialogContent: widget.dialogConfig!.dialogContent,
-          dialogTitle: widget.dialogConfig!.dialogTitle,
-          negativeText: widget.dialogConfig!.negativeText,
-          platform: widget.dialogConfig!.platform,
-        );
+    affirmativeText: widget.dialogConfig!.affirmativeText,
+    dialogContent: widget.dialogConfig!.dialogContent,
+    dialogTitle: widget.dialogConfig!.dialogTitle,
+    negativeText: widget.dialogConfig!.negativeText,
+    platform: widget.dialogConfig!.platform,
+  );
   PinTheme get _pinTheme => widget.pinTheme;
 
   Timer? _blinkDebounce;
 
   TextStyle get _textStyle => TextStyle(
-        fontSize: 20,
-        fontWeight: FontWeight.bold,
-      ).merge(widget.textStyle);
+    fontSize: 20,
+    fontWeight: FontWeight.bold,
+  ).merge(widget.textStyle);
 
   TextStyle get _hintStyle => _textStyle
       .copyWith(
-        color: _pinTheme.disabledColor,
-      )
+    color: _pinTheme.disabledColor,
+  )
       .merge(widget.hintStyle);
 
   bool get _hintAvailable => widget.hintCharacter != null;
@@ -390,14 +390,14 @@ class _PinCodeTextFieldState extends State<PinCodeTextField>
     if (widget.errorAnimationController != null) {
       _errorAnimationSubscription =
           widget.errorAnimationController!.stream.listen((errorAnimation) {
-        if (errorAnimation == ErrorAnimationType.shake) {
-          _controller.forward();
+            if (errorAnimation == ErrorAnimationType.shake) {
+              _controller.forward();
 
-          _setState(() => isInErrorMode = true);
-        } else if (errorAnimation == ErrorAnimationType.clear) {
-          _setState(() => isInErrorMode = false);
-        }
-      });
+              _setState(() => isInErrorMode = true);
+            } else if (errorAnimation == ErrorAnimationType.clear) {
+              _setState(() => isInErrorMode = false);
+            }
+          });
     }
     // If a default value is set in the TextEditingController, then set to UI
     if (_textEditingController!.text.isNotEmpty)
@@ -409,7 +409,11 @@ class _PinCodeTextFieldState extends State<PinCodeTextField>
     assert(widget.length > 0);
     assert(_pinTheme.fieldHeight > 0);
     assert(_pinTheme.fieldWidth > 0);
-    assert(_pinTheme.borderWidth >= 0);
+    assert(_pinTheme.activeBorderWidth >= 0);
+    assert(_pinTheme.selectedBorderWidth >= 0);
+    assert(_pinTheme.inactiveBorderWidth >= 0);
+    assert(_pinTheme.disabledBorderWidth >= 0);
+    assert(_pinTheme.errorBorderWidth >= 0);
     assert(_dialogConfig.affirmativeText != null &&
         _dialogConfig.affirmativeText!.isNotEmpty);
     assert(_dialogConfig.negativeText != null &&
@@ -476,7 +480,7 @@ class _PinCodeTextFieldState extends State<PinCodeTextField>
           }
           //  delay the onComplete event handler to give the onChange event handler enough time to complete
           Future.delayed(Duration(milliseconds: 300),
-              () => widget.onCompleted!(currentText));
+                  () => widget.onCompleted!(currentText));
         }
 
         if (widget.autoDismissKeyboard) _focusNode!.unfocus();
@@ -535,7 +539,7 @@ class _PinCodeTextFieldState extends State<PinCodeTextField>
       return _pinTheme.disabledColor;
     }
     if (((_selectedIndex == index) ||
-            (_selectedIndex == index + 1 && index + 1 == widget.length)) &&
+        (_selectedIndex == index + 1 && index + 1 == widget.length)) &&
         _focusNode!.hasFocus) {
       return _pinTheme.selectedColor;
     } else if (_selectedIndex > index) {
@@ -555,7 +559,7 @@ class _PinCodeTextFieldState extends State<PinCodeTextField>
     }
 
     if (((_selectedIndex == index) ||
-            (_selectedIndex == index + 1 && index + 1 == widget.length)) &&
+        (_selectedIndex == index + 1 && index + 1 == widget.length)) &&
         _focusNode!.hasFocus) {
       return _pinTheme.selectedBorderWidth;
     } else if (_selectedIndex > index) {
@@ -605,23 +609,23 @@ class _PinCodeTextFieldState extends State<PinCodeTextField>
     }
 
     final text =
-        widget.obscureText && _inputList[index].isNotEmpty && showObscured
-            ? widget.obscuringCharacter
-            : _inputList[index];
+    widget.obscureText && _inputList[index].isNotEmpty && showObscured
+        ? widget.obscuringCharacter
+        : _inputList[index];
     return widget.textGradient != null
         ? Gradiented(
-            gradient: widget.textGradient!,
-            child: Text(
-              text,
-              key: ValueKey(_inputList[index]),
-              style: _textStyle.copyWith(color: Colors.white),
-            ),
-          )
+      gradient: widget.textGradient!,
+      child: Text(
+        text,
+        key: ValueKey(_inputList[index]),
+        style: _textStyle.copyWith(color: Colors.white),
+      ),
+    )
         : Text(
-            text,
-            key: ValueKey(_inputList[index]),
-            style: _textStyle,
-          );
+      text,
+      key: ValueKey(_inputList[index]),
+      style: _textStyle,
+    );
   }
 
 // selects the right fill color for the field
@@ -630,7 +634,7 @@ class _PinCodeTextFieldState extends State<PinCodeTextField>
       return _pinTheme.disabledColor;
     }
     if (((_selectedIndex == index) ||
-            (_selectedIndex == index + 1 && index + 1 == widget.length)) &&
+        (_selectedIndex == index + 1 && index + 1 == widget.length)) &&
         _focusNode!.hasFocus) {
       return _pinTheme.selectedFillColor;
     } else if (_selectedIndex > index) {
@@ -642,7 +646,7 @@ class _PinCodeTextFieldState extends State<PinCodeTextField>
   /// Builds the widget to be shown
   Widget buildChild(int index) {
     if (((_selectedIndex == index) ||
-            (_selectedIndex == index + 1 && index + 1 == widget.length)) &&
+        (_selectedIndex == index + 1 && index + 1 == widget.length)) &&
         _focusNode!.hasFocus &&
         widget.showCursor) {
       final cursorColor = widget.cursorColor ??
@@ -708,55 +712,55 @@ class _PinCodeTextFieldState extends State<PinCodeTextField>
       useRootNavigator: true,
       builder: (context) => _dialogConfig.platform == PinCodePlatform.iOS
           ? CupertinoAlertDialog(
-              title: Text(_dialogConfig.dialogTitle!),
-              content: RichText(
-                text: TextSpan(
-                  text: _dialogConfig.dialogContent,
-                  style: TextStyle(
-                    color: Theme.of(context).textTheme.labelLarge!.color,
-                  ),
-                  children: [
-                    TextSpan(
-                      text: formattedPastedText,
-                      style: widget.pastedTextStyle ?? defaultPastedTextStyle,
-                    ),
-                    TextSpan(
-                      text: "?",
-                      style: TextStyle(
-                        color: Theme.of(context).textTheme.labelLarge!.color,
-                      ),
-                    )
-                  ],
-                ),
-              ),
-              actions: _getActionButtons(formattedPastedText),
-            )
-          : AlertDialog(
-              shape: RoundedRectangleBorder(
-                borderRadius: BorderRadius.circular(10),
-              ),
-              title: Text(_dialogConfig.dialogTitle!),
-              content: RichText(
-                text: TextSpan(
-                  text: _dialogConfig.dialogContent,
-                  style: TextStyle(
-                      color: Theme.of(context).textTheme.labelLarge!.color),
-                  children: [
-                    TextSpan(
-                      text: formattedPastedText,
-                      style: widget.pastedTextStyle ?? defaultPastedTextStyle,
-                    ),
-                    TextSpan(
-                      text: " ?",
-                      style: TextStyle(
-                        color: Theme.of(context).textTheme.labelLarge!.color,
-                      ),
-                    )
-                  ],
-                ),
-              ),
-              actions: _getActionButtons(formattedPastedText),
+        title: Text(_dialogConfig.dialogTitle!),
+        content: RichText(
+          text: TextSpan(
+            text: _dialogConfig.dialogContent,
+            style: TextStyle(
+              color: Theme.of(context).textTheme.labelLarge!.color,
             ),
+            children: [
+              TextSpan(
+                text: formattedPastedText,
+                style: widget.pastedTextStyle ?? defaultPastedTextStyle,
+              ),
+              TextSpan(
+                text: "?",
+                style: TextStyle(
+                  color: Theme.of(context).textTheme.labelLarge!.color,
+                ),
+              )
+            ],
+          ),
+        ),
+        actions: _getActionButtons(formattedPastedText),
+      )
+          : AlertDialog(
+        shape: RoundedRectangleBorder(
+          borderRadius: BorderRadius.circular(10),
+        ),
+        title: Text(_dialogConfig.dialogTitle!),
+        content: RichText(
+          text: TextSpan(
+            text: _dialogConfig.dialogContent,
+            style: TextStyle(
+                color: Theme.of(context).textTheme.labelLarge!.color),
+            children: [
+              TextSpan(
+                text: formattedPastedText,
+                style: widget.pastedTextStyle ?? defaultPastedTextStyle,
+              ),
+              TextSpan(
+                text: " ?",
+                style: TextStyle(
+                  color: Theme.of(context).textTheme.labelLarge!.color,
+                ),
+              )
+            ],
+          ),
+        ),
+        actions: _getActionButtons(formattedPastedText),
+      ),
     );
   }
 
@@ -824,7 +828,7 @@ class _PinCodeTextFieldState extends State<PinCodeTextField>
       child: Container(
         // adding the extra space at the bottom to show the error text from validator
         height: (widget.autovalidateMode == AutovalidateMode.disabled &&
-                widget.validator == null)
+            widget.validator == null)
             ? widget.pinTheme.fieldHeight
             : widget.pinTheme.fieldHeight + widget.errorTextSpace,
         color: widget.backgroundColor,
@@ -837,9 +841,9 @@ class _PinCodeTextFieldState extends State<PinCodeTextField>
               child: widget.useExternalAutoFillGroup
                   ? textField
                   : AutofillGroup(
-                      onDisposeAction: widget.onAutoFillDisposeAction,
-                      child: textField,
-                    ),
+                onDisposeAction: widget.onAutoFillDisposeAction,
+                child: textField,
+              ),
             ),
             Positioned(
               top: 0,
@@ -852,17 +856,17 @@ class _PinCodeTextFieldState extends State<PinCodeTextField>
                 },
                 onLongPress: widget.enabled
                     ? () async {
-                        var data = await Clipboard.getData("text/plain");
-                        if (data?.text?.isNotEmpty ?? false) {
-                          if (widget.beforeTextPaste != null) {
-                            if (widget.beforeTextPaste!(data!.text)) {
-                              _showPasteDialog(data.text!);
-                            }
-                          } else {
-                            _showPasteDialog(data!.text!);
-                          }
-                        }
+                  var data = await Clipboard.getData("text/plain");
+                  if (data?.text?.isNotEmpty ?? false) {
+                    if (widget.beforeTextPaste != null) {
+                      if (widget.beforeTextPaste!(data!.text)) {
+                        _showPasteDialog(data.text!);
                       }
+                    } else {
+                      _showPasteDialog(data!.text!);
+                    }
+                  }
+                }
                     : null,
                 child: Row(
                   mainAxisAlignment: widget.mainAxisAlignment,
@@ -892,7 +896,7 @@ class _PinCodeTextFieldState extends State<PinCodeTextField>
                     ? _getFillColorFromIndex(i)
                     : Colors.transparent,
                 boxShadow: (_pinTheme.activeBoxShadows != null ||
-                        _pinTheme.inActiveBoxShadows != null)
+                    _pinTheme.inActiveBoxShadows != null)
                     ? _getBoxShadowFromIndex(i)
                     : widget.boxShadows,
                 shape: _pinTheme.shape == PinCodeFieldShape.circle
@@ -901,15 +905,15 @@ class _PinCodeTextFieldState extends State<PinCodeTextField>
                 borderRadius: borderRadius,
                 border: _pinTheme.shape == PinCodeFieldShape.underline
                     ? Border(
-                        bottom: BorderSide(
-                          color: _getColorFromIndex(i),
-                          width: _getBorderWidthForIndex(i),
-                        ),
-                      )
+                  bottom: BorderSide(
+                    color: _getColorFromIndex(i),
+                    width: _getBorderWidthForIndex(i),
+                  ),
+                )
                     : Border.all(
-                        color: _getColorFromIndex(i),
-                        width: _getBorderWidthForIndex(i),
-                      ),
+                  color: _getColorFromIndex(i),
+                  width: _getBorderWidthForIndex(i),
+                ),
               ),
               child: Center(
                 child: AnimatedSwitcher(


### PR DESCRIPTION
With PR #335 the option to add indidual borderWidths was added however the old borderWidth variable was not removed which makes it frustrating for people updating their versions. With this change we would allow the user to continue to use borderWidth to set the value of all individual widths but still be able to override it with the individual widths. 