### PR TITLE
Separate border color and fill color for disabled fields

### DIFF
--- a/lib/src/models/pin_theme.dart
+++ b/lib/src/models/pin_theme.dart
@@ -22,6 +22,9 @@ class PinTheme {
   /// Colors of the input fields which don't have inputs. Default is [Colors.red]
   final Color inactiveFillColor;
 
+  /// The color to fill in the background of the input fields if the [PinCodeTextField] is disabled.
+  final Color disabledFillColor;
+
   /// Color of the input field when in error mode. Default is [Colors.redAccent]
   final Color errorBorderColor;
 
@@ -78,6 +81,7 @@ class PinTheme {
     this.activeFillColor = Colors.green,
     this.selectedFillColor = Colors.blue,
     this.inactiveFillColor = Colors.red,
+    this.disabledFillColor = Colors.grey,
     this.errorBorderColor = Colors.redAccent,
     this.activeBorderWidth = 2,
     this.selectedBorderWidth = 2,
@@ -96,6 +100,7 @@ class PinTheme {
     Color? activeFillColor,
     Color? selectedFillColor,
     Color? inactiveFillColor,
+    Color? disabledFillColor,
     Color? errorBorderColor,
     BorderRadius? borderRadius,
     double? fieldHeight,
@@ -125,6 +130,7 @@ class PinTheme {
       errorBorderColor: errorBorderColor ?? defaultValues.errorBorderColor,
       selectedColor: selectedColor ?? defaultValues.selectedColor,
       selectedFillColor: selectedFillColor ?? defaultValues.selectedFillColor,
+      disabledFillColor: disabledFillColor ?? defaultValues.disabledFillColor,
       shape: shape ?? defaultValues.shape,
       fieldOuterPadding: fieldOuterPadding ?? defaultValues.fieldOuterPadding,
       activeBoxShadows: activeBoxShadow ?? [],

--- a/lib/src/pin_code_fields.dart
+++ b/lib/src/pin_code_fields.dart
@@ -635,7 +635,7 @@ class _PinCodeTextFieldState extends State<PinCodeTextField>
 // selects the right fill color for the field
   Color _getFillColorFromIndex(int index) {
     if (!widget.enabled) {
-      return _pinTheme.disabledColor;
+      return _pinTheme.disabledFillColor;
     }
     if (((_selectedIndex == index) ||
         (_selectedIndex == index + 1 && index + 1 == widget.length)) &&

--- a/lib/src/pin_code_fields.dart
+++ b/lib/src/pin_code_fields.dart
@@ -1,4 +1,3 @@
-
 part of pin_code_fields;
 
 /// Pin code text fields which automatically changes focus and validates
@@ -870,14 +869,11 @@ class _PinCodeTextFieldState extends State<PinCodeTextField>
                           } else {
                             widget.showPasteConfirmationDialog ? _showPasteDialog(data!.text!) : _paste(data!.text!);
                           }
+                        } else {
+                          _showPasteDialog(data!.text!);
                         }
                       }
-                    } else {
-                      _showPasteDialog(data!.text!);
-                    }
-                  }
-                }
-                    : null,
+                : null,
                 child: Row(
                   mainAxisAlignment: widget.mainAxisAlignment,
                   children: _generateFields(),


### PR DESCRIPTION
Previously, the same color variable (disabledColor) is used for both the fill color and border color of disabled fields. This PR separates them so they can be set independently of each other.