### PR TITLE
fix: correctly applied boxShadows based on active/inactive shadows value in pin state

### DIFF
--- a/lib/src/pin_code_fields.dart
+++ b/lib/src/pin_code_fields.dart
@@ -908,8 +908,8 @@ class _PinCodeTextFieldState extends State<PinCodeTextField>
                 color: widget.enableActiveFill
                     ? _getFillColorFromIndex(i)
                     : Colors.transparent,
-                boxShadow: (_pinTheme.activeBoxShadows != null ||
-                    _pinTheme.inActiveBoxShadows != null)
+                boxShadow: (_pinTheme.activeBoxShadows?.isNotEmpty ?? false) ||
+                        (_pinTheme.inActiveBoxShadows?.isNotEmpty ?? false)
                     ? _getBoxShadowFromIndex(i)
                     : widget.boxShadows,
                 shape: _pinTheme.shape == PinCodeFieldShape.circle


### PR DESCRIPTION
Previously, boxShadows were not applied when active or inactive shadows were set. Now it checks if either is non-empty and applies shadows from the pin index.