### PR TITLE
Add mainAxisSize property for flexible sizing

### DIFF
--- a/packages/pin_code_fields/lib/src/material/form/material_pin_form_field.dart
+++ b/packages/pin_code_fields/lib/src/material/form/material_pin_form_field.dart
@@ -102,6 +102,7 @@ class MaterialPinFormField extends FormField<String> {
     this.separatorBuilder,
     this.mainAxisAlignment = MainAxisAlignment.center,
     this.crossAxisAlignment = CrossAxisAlignment.center,
+    this.mainAxisSize = MainAxisSize.min,
     // Cursor
     this.mouseCursor,
     // Keyboard
@@ -244,6 +245,12 @@ class MaterialPinFormField extends FormField<String> {
 
   /// How the cells should be aligned vertically.
   final CrossAxisAlignment crossAxisAlignment;
+
+  /// How much horizontal space the row of cells should occupy.
+  ///
+  /// Defaults to [MainAxisSize.min], which sizes the row to fit the cells.
+  /// Use [MainAxisSize.max] to expand the row to fill available space.
+  final MainAxisSize mainAxisSize;
 
   /// The mouse cursor to show when hovering over the widget.
   final MouseCursor? mouseCursor;
@@ -392,6 +399,7 @@ class _MaterialPinFormFieldState extends FormFieldState<String>
           separatorBuilder: widget.separatorBuilder,
           mainAxisAlignment: widget.mainAxisAlignment,
           crossAxisAlignment: widget.crossAxisAlignment,
+          mainAxisSize: widget.mainAxisSize,
         );
       },
     );

--- a/packages/pin_code_fields/lib/src/material/layout/material_pin_row.dart
+++ b/packages/pin_code_fields/lib/src/material/layout/material_pin_row.dart
@@ -21,6 +21,7 @@ class MaterialPinRow extends StatelessWidget {
     this.separatorBuilder,
     this.mainAxisAlignment = MainAxisAlignment.center,
     this.crossAxisAlignment = CrossAxisAlignment.center,
+    this.mainAxisSize = MainAxisSize.min,
   });
 
   /// List of cell data for each PIN position.
@@ -60,10 +61,19 @@ class MaterialPinRow extends StatelessWidget {
   /// How the cells should be aligned vertically.
   final CrossAxisAlignment crossAxisAlignment;
 
+  /// How much horizontal space the row should occupy.
+  ///
+  /// Defaults to [MainAxisSize.min], which makes the row wrap its contents
+  /// and take up only as much horizontal space as needed by the cells and
+  /// separators. Use [MainAxisSize.max] when you want the row to expand to
+  /// fill the available horizontal space, for example to have the cells
+  /// distributed across the full width of their parent.
+  final MainAxisSize mainAxisSize;
+
   @override
   Widget build(BuildContext context) {
     return Row(
-      mainAxisSize: MainAxisSize.min,
+      mainAxisSize: mainAxisSize,
       mainAxisAlignment: mainAxisAlignment,
       crossAxisAlignment: crossAxisAlignment,
       children: _buildChildren(context),

--- a/packages/pin_code_fields/lib/src/material/material_pin_field.dart
+++ b/packages/pin_code_fields/lib/src/material/material_pin_field.dart
@@ -77,6 +77,7 @@ class MaterialPinField extends StatefulWidget {
     this.separatorBuilder,
     this.mainAxisAlignment = MainAxisAlignment.center,
     this.crossAxisAlignment = CrossAxisAlignment.center,
+    this.mainAxisSize = MainAxisSize.min,
     // Cursor
     this.mouseCursor,
     // Keyboard
@@ -253,6 +254,12 @@ class MaterialPinField extends StatefulWidget {
   ///
   /// Defaults to [CrossAxisAlignment.center].
   final CrossAxisAlignment crossAxisAlignment;
+
+  /// How much horizontal space the row of cells should occupy.
+  ///
+  /// Defaults to [MainAxisSize.min], which sizes the row to fit the cells.
+  /// Use [MainAxisSize.max] to expand the row to fill available space.
+  final MainAxisSize mainAxisSize;
 
   /// The mouse cursor to show when hovering over the widget.
   ///
@@ -437,6 +444,7 @@ class _MaterialPinFieldState extends State<MaterialPinField>
           separatorBuilder: widget.separatorBuilder,
           mainAxisAlignment: widget.mainAxisAlignment,
           crossAxisAlignment: widget.crossAxisAlignment,
+          mainAxisSize: widget.mainAxisSize,
         );
       },
     );

--- a/packages/pin_code_fields/test/material_pin_field_test.dart
+++ b/packages/pin_code_fields/test/material_pin_field_test.dart
@@ -1,0 +1,89 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:pin_code_fields/pin_code_fields.dart';
+
+void main() {
+  group('MaterialPinField mainAxisSize', () {
+    Finder findPinRowRow() => find.descendant(
+          of: find.byType(MaterialPinRow),
+          matching: find.byType(Row),
+        );
+
+    testWidgets('defaults to MainAxisSize.min', (tester) async {
+      await tester.pumpWidget(
+        const MaterialApp(
+          home: Scaffold(
+            body: MaterialPinField(length: 4),
+          ),
+        ),
+      );
+
+      final row = tester.widget<Row>(findPinRowRow());
+      expect(row.mainAxisSize, MainAxisSize.min);
+    });
+
+    testWidgets('passes MainAxisSize.max through to MaterialPinRow',
+        (tester) async {
+      await tester.pumpWidget(
+        const MaterialApp(
+          home: Scaffold(
+            body: MaterialPinField(
+              length: 4,
+              mainAxisSize: MainAxisSize.max,
+            ),
+          ),
+        ),
+      );
+
+      final row = tester.widget<Row>(findPinRowRow());
+      expect(row.mainAxisSize, MainAxisSize.max);
+    });
+
+    testWidgets('MainAxisSize.max expands to fill available width',
+        (tester) async {
+      const containerWidth = 400.0;
+
+      await tester.pumpWidget(
+        const MaterialApp(
+          home: Scaffold(
+            body: Center(
+              child: SizedBox(
+                width: containerWidth,
+                child: MaterialPinField(
+                  length: 4,
+                  mainAxisSize: MainAxisSize.max,
+                ),
+              ),
+            ),
+          ),
+        ),
+      );
+
+      final rowSize = tester.getSize(findPinRowRow());
+      expect(rowSize.width, containerWidth);
+    });
+
+    testWidgets('MainAxisSize.min only takes needed width', (tester) async {
+      const containerWidth = 400.0;
+
+      await tester.pumpWidget(
+        const MaterialApp(
+          home: Scaffold(
+            body: Center(
+              child: SizedBox(
+                width: containerWidth,
+                child: MaterialPinField(
+                  length: 4,
+                  mainAxisSize: MainAxisSize.min,
+                ),
+              ),
+            ),
+          ),
+        ),
+      );
+
+      final rowSize = tester.getSize(findPinRowRow());
+      expect(rowSize.width, lessThan(containerWidth));
+    });
+  });
+}

--- a/packages/pin_code_fields/test/material_pin_form_field_test.dart
+++ b/packages/pin_code_fields/test/material_pin_form_field_test.dart
@@ -155,8 +155,7 @@ void main() {
         expect(find.byType(ErrorShake), findsOneWidget);
       });
 
-      testWidgets(
-          'controller error and form error coexist independently',
+      testWidgets('controller error and form error coexist independently',
           (tester) async {
         final formKey = GlobalKey<FormState>();
         final controller = PinInputController();
@@ -428,6 +427,94 @@ void main() {
 
         // Should restore initial value
         expect(controller.text, '12');
+      });
+    });
+
+    group('mainAxisSize', () {
+      Finder findPinRowRow() => find.descendant(
+            of: find.byType(MaterialPinRow),
+            matching: find.byType(Row),
+          );
+
+      testWidgets('defaults to MainAxisSize.min', (tester) async {
+        await tester.pumpWidget(
+          buildApp(
+            child: Form(
+              child: MaterialPinFormField(length: 4),
+            ),
+          ),
+        );
+
+        final row = tester.widget<Row>(findPinRowRow());
+        expect(row.mainAxisSize, MainAxisSize.min);
+      });
+
+      testWidgets('passes MainAxisSize.max through to MaterialPinRow',
+          (tester) async {
+        await tester.pumpWidget(
+          buildApp(
+            child: Form(
+              child: MaterialPinFormField(
+                length: 4,
+                mainAxisSize: MainAxisSize.max,
+              ),
+            ),
+          ),
+        );
+
+        final row = tester.widget<Row>(findPinRowRow());
+        expect(row.mainAxisSize, MainAxisSize.max);
+      });
+
+      testWidgets('MainAxisSize.max expands to fill available width',
+          (tester) async {
+        const containerWidth = 400.0;
+
+        await tester.pumpWidget(
+          MaterialApp(
+            home: Scaffold(
+              body: Center(
+                child: SizedBox(
+                  width: containerWidth,
+                  child: Form(
+                    child: MaterialPinFormField(
+                      length: 4,
+                      mainAxisSize: MainAxisSize.max,
+                    ),
+                  ),
+                ),
+              ),
+            ),
+          ),
+        );
+
+        final rowSize = tester.getSize(findPinRowRow());
+        expect(rowSize.width, containerWidth);
+      });
+
+      testWidgets('MainAxisSize.min only takes needed width', (tester) async {
+        const containerWidth = 400.0;
+
+        await tester.pumpWidget(
+          MaterialApp(
+            home: Scaffold(
+              body: Center(
+                child: SizedBox(
+                  width: containerWidth,
+                  child: Form(
+                    child: MaterialPinFormField(
+                      length: 4,
+                      mainAxisSize: MainAxisSize.min,
+                    ),
+                  ),
+                ),
+              ),
+            ),
+          ),
+        );
+
+        final rowSize = tester.getSize(findPinRowRow());
+        expect(rowSize.width, lessThan(containerWidth));
       });
     });
 


### PR DESCRIPTION
Exposes the `mainAxisSize` property on `MaterialPinField`, `MaterialPinFormField`, and `MaterialPinRow`, which was previously hardcoded to `MainAxisSize.min`.

This allows users to set `MainAxisSize.max` so that `mainAxisAlignment` values like `spaceBetween` and `spaceEvenly` work as expected when the row should fill available width.

Defaults to `MainAxisSize.min` — no breaking changes.