### PR TITLE
fix: suppress semantic hint and focused state when disabled (#427)

### DIFF
--- a/packages/pin_code_fields/lib/src/core/pin_input.dart
+++ b/packages/pin_code_fields/lib/src/core/pin_input.dart
@@ -942,11 +942,13 @@ class _PinInputState extends State<PinInput>
         ? '●' * filledCount // Don't reveal obscured text
         : currentText;
 
-    // Use custom hint builder if provided, otherwise use default
-    final semanticHint = widget.semanticHintBuilder?.call(filledCount, widget.length) ??
-        (filledCount < widget.length
-            ? 'Enter ${widget.length - filledCount} more ${widget.length - filledCount == 1 ? 'digit' : 'digits'}'
-            : 'PIN complete');
+    // Suppress hint when disabled so the platform can announce "dimmed" unobstructed.
+    final semanticHint = widget.enabled
+        ? (widget.semanticHintBuilder?.call(filledCount, widget.length) ??
+            (filledCount < widget.length
+                ? 'Enter ${widget.length - filledCount} more ${widget.length - filledCount == 1 ? 'digit' : 'digits'}'
+                : 'PIN complete'))
+        : null;
 
     return Semantics(
       label: widget.semanticLabel ?? '${widget.length}-digit PIN code field',
@@ -954,7 +956,7 @@ class _PinInputState extends State<PinInput>
       hint: semanticHint,
       textField: true,
       enabled: widget.enabled,
-      focused: _focusNode.hasFocus,
+      focused: widget.enabled && _focusNode.hasFocus,
       obscured: widget.obscureText,
       child: content,
     );

--- a/packages/pin_code_fields/test/pin_input_test.dart
+++ b/packages/pin_code_fields/test/pin_input_test.dart
@@ -526,6 +526,140 @@ void main() {
         expect(semantics.hasFlag(SemanticsFlag.isEnabled), false);
       });
 
+      testWidgets('suppresses semantic hint when disabled', (tester) async {
+        await tester.pumpWidget(
+          MaterialApp(
+            home: Scaffold(
+              body: PinInput(
+                length: 6,
+                enabled: false,
+                builder: (context, cells) => Row(
+                  children: cells.map((c) => Text(c.character ?? '-')).toList(),
+                ),
+              ),
+            ),
+          ),
+        );
+
+        final semanticsFinder = find.byWidgetPredicate((widget) {
+          if (widget is Semantics) {
+            return widget.properties.label?.contains('PIN code field') ?? false;
+          }
+          return false;
+        });
+        final semantics = tester.getSemantics(semanticsFinder);
+        // Hint must be absent so the platform can announce "dimmed" cleanly.
+        expect(semantics.hint, isEmpty);
+      });
+
+      testWidgets('suppresses semantic hint when disabled with pre-filled value',
+          (tester) async {
+        final controller = PinInputController(text: '1234');
+
+        await tester.pumpWidget(
+          MaterialApp(
+            home: Scaffold(
+              body: PinInput(
+                length: 4,
+                enabled: false,
+                pinController: controller,
+                builder: (context, cells) => Row(
+                  children: cells.map((c) => Text(c.character ?? '-')).toList(),
+                ),
+              ),
+            ),
+          ),
+        );
+
+        await tester.pump();
+
+        final semanticsFinder = find.byWidgetPredicate((widget) {
+          if (widget is Semantics) {
+            return widget.properties.label?.contains('PIN code field') ?? false;
+          }
+          return false;
+        });
+        final semantics = tester.getSemantics(semanticsFinder);
+        // "PIN complete" hint must also be suppressed when disabled.
+        expect(semantics.hint, isEmpty);
+      });
+
+      testWidgets('suppresses custom semanticHintBuilder when disabled',
+          (tester) async {
+        await tester.pumpWidget(
+          MaterialApp(
+            home: Scaffold(
+              body: PinInput(
+                length: 4,
+                enabled: false,
+                semanticHintBuilder: (_, __) => 'Enter your security code',
+                builder: (context, cells) => Row(
+                  children: cells.map((c) => Text(c.character ?? '-')).toList(),
+                ),
+              ),
+            ),
+          ),
+        );
+
+        final semanticsFinder = find.byWidgetPredicate((widget) {
+          if (widget is Semantics) {
+            return widget.properties.label?.contains('PIN code field') ?? false;
+          }
+          return false;
+        });
+        final semantics = tester.getSemantics(semanticsFinder);
+        // Custom hint builder output must be suppressed too.
+        expect(semantics.hint, isEmpty);
+      });
+
+      testWidgets(
+          'does not report focused state when field is disabled after focus',
+          (tester) async {
+        bool enabled = true;
+
+        await tester.pumpWidget(
+          StatefulBuilder(
+            builder: (context, setState) => MaterialApp(
+              home: Scaffold(
+                body: Column(
+                  children: [
+                    PinInput(
+                      length: 4,
+                      enabled: enabled,
+                      autoFocus: true,
+                      builder: (context, cells) => Row(
+                        children:
+                            cells.map((c) => Text(c.character ?? '-')).toList(),
+                      ),
+                    ),
+                    ElevatedButton(
+                      onPressed: () => setState(() => enabled = false),
+                      child: const Text('Disable'),
+                    ),
+                  ],
+                ),
+              ),
+            ),
+          ),
+        );
+
+        await tester.pump();
+
+        // Disable the field while it potentially has focus.
+        await tester.tap(find.text('Disable'));
+        await tester.pump();
+
+        final semanticsFinder = find.byWidgetPredicate((widget) {
+          if (widget is Semantics) {
+            return widget.properties.label?.contains('PIN code field') ?? false;
+          }
+          return false;
+        });
+        final semantics = tester.getSemantics(semanticsFinder);
+        // ignore: deprecated_member_use
+        expect(semantics.hasFlag(SemanticsFlag.isFocused), false);
+      });
+
       testWidgets('uses custom semanticHintBuilder for dynamic hints',
           (tester) async {
         await tester.pumpWidget(


### PR DESCRIPTION
**Problem**                                                                                                                                                                                                                                                                                                          
                                                                                                                                                                                                                                                                                                                   
  When PinInput (and MaterialPinField) is rendered with enabled: false, screen readers were still announcing interactive hints like "Enter 6 more digits" or "PIN complete", and the field could report itself as focused. This told visually impaired users the field was editable when it wasn't.                
                  
  The expected behavior — "Text field, dimmed" announced automatically in the user's OS language — was being overridden by our explicit hint value on the Semantics node.                                                                                                                                          
                  
  **Root cause**                                                                                                                                                                                                                                                                                                       
                  
  In _PinInputState.build(), two properties on the Semantics widget conflicted with the enabled: false state. The hint was always computed and set, even when disabled — the string "Enter N more digits" explicitly told screen readers the field accepts input. The focused property was also set directly from  
  _focusNode.hasFocus without guarding against the disabled state, meaning a field could be reported as focused while disabled.
                                                                                                                                                                                                                                                                                                                   
  **Fix**             

  Two targeted changes in packages/pin_code_fields/lib/src/core/pin_input.dart. semanticHint is now gated behind widget.enabled and returns null when disabled, letting the platform produce its native "dimmed" suffix without contradiction. focused is changed from _focusNode.hasFocus to widget.enabled &&    
  _focusNode.hasFocus so a disabled field can never be semantically focused. No new public API. No behavior change when enabled: true.
                                                                                                                                                                                                                                                                                                                   
  **Tests**           

  Four new cases added to the Semantics group in pin_input_test.dart: an empty disabled field has no hint, the "PIN complete" hint is also suppressed when disabled, the semanticHintBuilder callback is gated behind enabled too, and the focused guard holds when the field is disabled mid-session.  
  
  ### Closes #427